### PR TITLE
Create shared_element_transition.d.ts file

### DIFF
--- a/shared_element_transition.d.ts
+++ b/shared_element_transition.d.ts
@@ -1,13 +1,12 @@
 interface DocumentTransition {
-    start(callback: () => Promise<void> | void): Promise<void>;
-    abandon(): void;
-  }
-  
-  interface Document {
-    createDocumentTransition(): DocumentTransition;
-  }
-  
-  interface CSSStyleDeclaration {
-    pageTransitionTag: string;
-  }
-  
+  start(callback: () => Promise<void> | void): Promise<void>;
+  abandon(): void;
+}
+
+interface Document {
+  createDocumentTransition(): DocumentTransition;
+}
+
+interface CSSStyleDeclaration {
+  pageTransitionTag: string;
+}

--- a/shared_element_transition.d.ts
+++ b/shared_element_transition.d.ts
@@ -10,3 +10,4 @@ interface DocumentTransition {
   interface CSSStyleDeclaration {
     pageTransitionTag: string;
   }
+  

--- a/shared_element_transition.d.ts
+++ b/shared_element_transition.d.ts
@@ -1,0 +1,12 @@
+interface DocumentTransition {
+    start(callback: () => Promise<void> | void): Promise<void>;
+    abandon(): void;
+  }
+  
+  interface Document {
+    createDocumentTransition(): DocumentTransition;
+  }
+  
+  interface CSSStyleDeclaration {
+    pageTransitionTag: string;
+  }

--- a/shared_element_transition.d.ts
+++ b/shared_element_transition.d.ts
@@ -1,4 +1,4 @@
-interface DocumentTransition {
+declare class DocumentTransition {
   start(callback: () => Promise<void> | void): Promise<void>;
   abandon(): void;
 }


### PR DESCRIPTION
There were a few methods that I saw in the browser implementation that I thought may need to also be included, but I didn't see any mention of them in the explainer so I left them out. The one exception I made was abandon(), which seemed like that was probably implemented and could be used by users.

I also couldn't find an up to date spec to confirm, [this one](https://tabatkins.github.io/specs/css-shared-element-transitions/) seems out of date.

But let me know if there are other methods or properties (setElement, ignoreCSSTaggedElements, and I didn't see an ongoingTransition global variable anywhere) that you want included in this d.ts file.